### PR TITLE
Fix diagnostic tab

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -8,8 +8,7 @@ Phase Four focuses on security enhancements and compliance features. The followi
 
 1. **Agentic Security Framework** - Begin with the agent validation system
 2. **WordPress Security Integration** - Focus on capability mapping and nonce systems  
-3. **AI Terms & Conditions Consent** - Implement user consent flow and persistence
-4. **Integrated Security Implementation** - Combine all security systems into unified approach
+3. **Integrated Security Implementation** - Combine all security systems into unified approach
 
 ### Implementation Order and Starting Points
 

--- a/includes/class-mpai-diagnostics.php
+++ b/includes/class-mpai-diagnostics.php
@@ -1,0 +1,352 @@
+<?php
+/**
+ * Diagnostics System
+ * 
+ * Provides a unified framework for registering, managing, and running diagnostic tests
+ * 
+ * @package MemberPress AI Assistant
+ */
+
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+
+class MPAI_Diagnostics {
+    // Registry of all diagnostic tests
+    private static $tests = [];
+    
+    // Registry of all diagnostic categories
+    private static $categories = [];
+    
+    /**
+     * Register a diagnostic test
+     * 
+     * @param array $test_data Test configuration
+     * @return bool Success
+     */
+    public static function register_test($test_data) {
+        // Validate required fields
+        if (!isset($test_data['id']) || !isset($test_data['name']) || !isset($test_data['category'])) {
+            error_log('MPAI ERROR: Invalid test registration data');
+            return false;
+        }
+        
+        // Add to registry
+        self::$tests[$test_data['id']] = $test_data;
+        return true;
+    }
+    
+    /**
+     * Register a diagnostic category
+     * 
+     * @param array $category_data Category configuration
+     * @return bool Success
+     */
+    public static function register_category($category_data) {
+        // Validate required fields
+        if (!isset($category_data['id']) || !isset($category_data['name'])) {
+            error_log('MPAI ERROR: Invalid category registration data');
+            return false;
+        }
+        
+        // Add to registry
+        self::$categories[$category_data['id']] = $category_data;
+        return true;
+    }
+    
+    /**
+     * Get all registered tests
+     * 
+     * @return array Tests
+     */
+    public static function get_tests() {
+        return self::$tests;
+    }
+    
+    /**
+     * Get all registered categories
+     * 
+     * @return array Categories
+     */
+    public static function get_categories() {
+        // If no categories are registered, use a default set
+        if (empty(self::$categories)) {
+            return [
+                'core' => [
+                    'id' => 'core',
+                    'name' => __('Core System', 'memberpress-ai-assistant'),
+                    'description' => __('Tests for core system functionality', 'memberpress-ai-assistant')
+                ],
+                'api' => [
+                    'id' => 'api',
+                    'name' => __('API Connections', 'memberpress-ai-assistant'),
+                    'description' => __('Tests for API connectivity and functionality', 'memberpress-ai-assistant')
+                ],
+                'tools' => [
+                    'id' => 'tools',
+                    'name' => __('AI Tools', 'memberpress-ai-assistant'),
+                    'description' => __('Tests for AI tool functionality', 'memberpress-ai-assistant')
+                ],
+                'integration' => [
+                    'id' => 'integration',
+                    'name' => __('Integration Tests', 'memberpress-ai-assistant'),
+                    'description' => __('Tests for integration with WordPress and external systems', 'memberpress-ai-assistant')
+                ]
+            ];
+        }
+        
+        return self::$categories;
+    }
+    
+    /**
+     * Get tests by category
+     * 
+     * @param string $category Category ID
+     * @return array Tests in category
+     */
+    public static function get_tests_by_category($category) {
+        return array_filter(self::$tests, function($test) use ($category) {
+            return $test['category'] === $category;
+        });
+    }
+    
+    /**
+     * Get a specific test
+     * 
+     * @param string $test_id Test ID
+     * @return array|null Test data or null if not found
+     */
+    public static function get_test($test_id) {
+        return isset(self::$tests[$test_id]) ? self::$tests[$test_id] : null;
+    }
+    
+    /**
+     * Register core diagnostic tests
+     */
+    public static function register_core_tests() {
+        // Register System Information test
+        self::register_test([
+            'id' => 'system-info',
+            'category' => 'core',
+            'name' => __('System Information', 'memberpress-ai-assistant'),
+            'description' => __('Get detailed information about your WordPress and PHP environment', 'memberpress-ai-assistant'),
+            'test_callback' => 'mpai_run_system_info_test',
+            'doc_url' => 'system-information.md'
+        ]);
+        
+        // Register OpenAI API Connection test
+        self::register_test([
+            'id' => 'openai-connection',
+            'category' => 'api',
+            'name' => __('OpenAI API Connection', 'memberpress-ai-assistant'),
+            'description' => __('Test connection to the OpenAI API', 'memberpress-ai-assistant'),
+            'test_callback' => 'mpai_test_openai_connection',
+            'doc_url' => 'api-connections.md#openai'
+        ]);
+        
+        // Register Anthropic API Connection test
+        self::register_test([
+            'id' => 'anthropic-connection',
+            'category' => 'api',
+            'name' => __('Anthropic API Connection', 'memberpress-ai-assistant'),
+            'description' => __('Test connection to the Anthropic API', 'memberpress-ai-assistant'),
+            'test_callback' => 'mpai_test_anthropic_connection',
+            'doc_url' => 'api-connections.md#anthropic'
+        ]);
+        
+        // Register Error Recovery System test
+        self::register_test([
+            'id' => 'error-recovery',
+            'category' => 'core',
+            'name' => __('Error Recovery System', 'memberpress-ai-assistant'),
+            'description' => __('Test the Error Recovery System functionality', 'memberpress-ai-assistant'),
+            'test_callback' => 'mpai_test_error_recovery',
+            'direct_url' => 'test/test-error-recovery-page.php',
+            'doc_url' => 'error-recovery-system.md'
+        ]);
+    }
+    
+    /**
+     * Run a diagnostic test
+     * 
+     * @param string $test_id Test ID
+     * @param array $params Test parameters
+     * @return array Test results
+     */
+    public static function run_test($test_id, $params = []) {
+        $test = self::get_test($test_id);
+        
+        if (!$test || !isset($test['test_callback']) || !is_callable($test['test_callback'])) {
+            return [
+                'success' => false,
+                'message' => __('Invalid test ID or callback', 'memberpress-ai-assistant'),
+                'test_id' => $test_id
+            ];
+        }
+        
+        try {
+            // Start timing
+            $start_time = microtime(true);
+            
+            // Call the test callback
+            $result = call_user_func($test['test_callback'], $params);
+            
+            // End timing
+            $end_time = microtime(true);
+            $total_time = $end_time - $start_time;
+            
+            // Add timing if not already included
+            if (!isset($result['timing'])) {
+                $result['timing'] = [
+                    'start' => $start_time,
+                    'end' => $end_time,
+                    'total' => $total_time,
+                ];
+            }
+            
+            // Add test metadata
+            $result['test_id'] = $test_id;
+            $result['test_name'] = $test['name'];
+            
+            return $result;
+        } catch (Exception $e) {
+            return [
+                'success' => false,
+                'message' => 'Error running test: ' . $e->getMessage(),
+                'error' => $e->getMessage(),
+                'test_id' => $test_id,
+                'test_name' => $test['name'],
+            ];
+        }
+    }
+    
+    /**
+     * Run all tests in a category
+     * 
+     * @param string $category_id Category ID
+     * @param array $params Test parameters
+     * @return array Test results
+     */
+    public static function run_category_tests($category_id, $params = []) {
+        $tests = self::get_tests_by_category($category_id);
+        $results = [];
+        
+        foreach ($tests as $test_id => $test) {
+            $results[$test_id] = self::run_test($test_id, $params);
+        }
+        
+        return [
+            'success' => true,
+            'category_id' => $category_id,
+            'category_name' => self::get_categories()[$category_id]['name'],
+            'results' => $results
+        ];
+    }
+    
+    /**
+     * Run all registered tests
+     * 
+     * @param array $params Test parameters
+     * @return array Test results
+     */
+    public static function run_all_tests($params = []) {
+        $results = [];
+        
+        foreach (self::$tests as $test_id => $test) {
+            $results[$test_id] = self::run_test($test_id, $params);
+        }
+        
+        return [
+            'success' => true,
+            'results' => $results
+        ];
+    }
+    
+    /**
+     * Initialize diagnostic system and register tests
+     */
+    public static function init() {
+        // Register core tests
+        self::register_core_tests();
+        
+        // Allow plugins and themes to register tests
+        do_action('mpai_register_diagnostic_tests');
+        
+        // Register AJAX handlers for running tests
+        add_action('wp_ajax_mpai_run_diagnostic_test', [self::class, 'ajax_run_test']);
+        add_action('wp_ajax_mpai_run_category_tests', [self::class, 'ajax_run_category_tests']);
+        add_action('wp_ajax_mpai_run_all_tests', [self::class, 'ajax_run_all_tests']);
+    }
+    
+    /**
+     * AJAX handler for running a single diagnostic test
+     */
+    public static function ajax_run_test() {
+        // Check nonce for security
+        check_ajax_referer('mpai_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized access', 'memberpress-ai-assistant')]);
+            return;
+        }
+        
+        $test_id = isset($_POST['test_id']) ? sanitize_key($_POST['test_id']) : '';
+        if (empty($test_id)) {
+            wp_send_json_error(['message' => __('Missing test ID', 'memberpress-ai-assistant')]);
+            return;
+        }
+        
+        $result = self::run_test($test_id, $_POST);
+        wp_send_json_success($result);
+    }
+    
+    /**
+     * AJAX handler for running all tests in a category
+     */
+    public static function ajax_run_category_tests() {
+        // Check nonce for security
+        check_ajax_referer('mpai_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized access', 'memberpress-ai-assistant')]);
+            return;
+        }
+        
+        $category_id = isset($_POST['category_id']) ? sanitize_key($_POST['category_id']) : '';
+        if (empty($category_id)) {
+            wp_send_json_error(['message' => __('Missing category ID', 'memberpress-ai-assistant')]);
+            return;
+        }
+        
+        $result = self::run_category_tests($category_id, $_POST);
+        wp_send_json_success($result);
+    }
+    
+    /**
+     * AJAX handler for running all diagnostic tests
+     */
+    public static function ajax_run_all_tests() {
+        // Check nonce for security
+        check_ajax_referer('mpai_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(['message' => __('Unauthorized access', 'memberpress-ai-assistant')]);
+            return;
+        }
+        
+        $result = self::run_all_tests($_POST);
+        wp_send_json_success($result);
+    }
+    
+    /**
+     * Render the diagnostic interface
+     */
+    public static function render_interface() {
+        // Include template for diagnostic interface
+        include MPAI_PLUGIN_DIR . 'includes/templates/diagnostic-interface.php';
+    }
+}
+
+// Initialize diagnostics system
+MPAI_Diagnostics::init();

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -525,34 +525,71 @@ settings_errors('mpai_messages');
             
             
             <?php 
-            // Include the diagnostics tab with error handling
-            error_log('MPAI DEBUG: About to include diagnostics tab from: ' . MPAI_PLUGIN_DIR . 'includes/settings-diagnostic.php');
+            // Load the new diagnostic system with error handling
+            error_log('MPAI DEBUG: Loading improved diagnostic system...');
             
-            $diagnostic_file = MPAI_PLUGIN_DIR . 'includes/settings-diagnostic.php';
-            if (file_exists($diagnostic_file)) {
-                error_log('MPAI DEBUG: Diagnostic file exists, including it');
+            // Check for the diagnostic class
+            if (!class_exists('MPAI_Diagnostics')) {
+                $diagnostics_class_file = MPAI_PLUGIN_DIR . 'includes/class-mpai-diagnostics.php';
+                if (file_exists($diagnostics_class_file)) {
+                    error_log('MPAI DEBUG: Loading MPAI_Diagnostics class file...');
+                    try {
+                        include_once $diagnostics_class_file;
+                        error_log('MPAI DEBUG: MPAI_Diagnostics class loaded successfully');
+                    } catch (Exception $e) {
+                        error_log('MPAI ERROR: Failed to load diagnostics class: ' . $e->getMessage());
+                    }
+                } else {
+                    error_log('MPAI ERROR: Diagnostics class file not found at: ' . $diagnostics_class_file);
+                }
+            }
+            
+            // Render the diagnostic interface if the class exists
+            if (class_exists('MPAI_Diagnostics')) {
+                error_log('MPAI DEBUG: Rendering improved diagnostics interface...');
                 try {
-                    include_once $diagnostic_file;
-                    error_log('MPAI DEBUG: Diagnostic file included successfully');
+                    MPAI_Diagnostics::render_interface();
+                    error_log('MPAI DEBUG: Diagnostics interface rendered successfully');
                 } catch (Exception $e) {
-                    error_log('MPAI ERROR: Exception including diagnostic file: ' . $e->getMessage());
-                    // Add a fallback UI if the file can't be included
+                    error_log('MPAI ERROR: Exception rendering diagnostics interface: ' . $e->getMessage());
+                    // Fallback UI on error
                     echo '<div id="tab-diagnostic" class="mpai-settings-tab" style="display: none;">';
                     echo '<h3>Diagnostics</h3>';
                     echo '<div class="mpai-notice mpai-notice-error">';
-                    echo '<p>Error loading diagnostics tab: ' . esc_html($e->getMessage()) . '</p>';
+                    echo '<p>Error rendering diagnostics interface: ' . esc_html($e->getMessage()) . '</p>';
                     echo '</div>';
                     echo '</div>';
                 }
             } else {
-                error_log('MPAI ERROR: Diagnostic file not found at: ' . $diagnostic_file);
-                // Add a fallback UI if the file doesn't exist
-                echo '<div id="tab-diagnostic" class="mpai-settings-tab" style="display: none;">';
-                echo '<h3>Diagnostics</h3>';
-                echo '<div class="mpai-notice mpai-notice-error">';
-                echo '<p>Diagnostic file not found. This component may not be available in the current branch.</p>';
-                echo '</div>';
-                echo '</div>';
+                // Try loading the legacy diagnostic file as fallback
+                error_log('MPAI DEBUG: Falling back to legacy diagnostics tab...');
+                
+                $diagnostic_file = MPAI_PLUGIN_DIR . 'includes/settings-diagnostic.php';
+                if (file_exists($diagnostic_file)) {
+                    error_log('MPAI DEBUG: Legacy diagnostic file exists, including it');
+                    try {
+                        include_once $diagnostic_file;
+                        error_log('MPAI DEBUG: Legacy diagnostic file included successfully');
+                    } catch (Exception $e) {
+                        error_log('MPAI ERROR: Exception including legacy diagnostic file: ' . $e->getMessage());
+                        // Add a fallback UI if the file can't be included
+                        echo '<div id="tab-diagnostic" class="mpai-settings-tab" style="display: none;">';
+                        echo '<h3>Diagnostics</h3>';
+                        echo '<div class="mpai-notice mpai-notice-error">';
+                        echo '<p>Error loading diagnostics tab: ' . esc_html($e->getMessage()) . '</p>';
+                        echo '</div>';
+                        echo '</div>';
+                    }
+                } else {
+                    error_log('MPAI ERROR: Diagnostic file not found at: ' . $diagnostic_file);
+                    // Add a fallback UI if the file doesn't exist
+                    echo '<div id="tab-diagnostic" class="mpai-settings-tab" style="display: none;">';
+                    echo '<h3>Diagnostics</h3>';
+                    echo '<div class="mpai-notice mpai-notice-error">';
+                    echo '<p>Diagnostic file not found. This component may not be available in the current branch.</p>';
+                    echo '</div>';
+                    echo '</div>';
+                }
             }
             ?>
         </div>

--- a/includes/templates/diagnostic-interface.php
+++ b/includes/templates/diagnostic-interface.php
@@ -1,0 +1,549 @@
+<?php
+/**
+ * Diagnostics Interface Template
+ * 
+ * Provides a well-structured UI for the diagnostic system
+ * 
+ * @package MemberPress AI Assistant
+ */
+
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+?>
+
+<div id="tab-diagnostic" class="mpai-settings-tab" style="display: none;">
+    <h3><?php _e('System Diagnostics', 'memberpress-ai-assistant'); ?></h3>
+    <p><?php _e('Run various diagnostic tests to check the health of your MemberPress AI Assistant installation.', 'memberpress-ai-assistant'); ?></p>
+    
+    <div class="mpai-diagnostics-container">
+        <div class="mpai-test-categories">
+            <ul class="mpai-category-tabs">
+                <?php foreach (MPAI_Diagnostics::get_categories() as $category_id => $category): ?>
+                    <li>
+                        <a href="#category-<?php echo esc_attr($category_id); ?>" class="<?php echo $category_id === 'core' ? 'active' : ''; ?>">
+                            <?php echo esc_html($category['name']); ?>
+                        </a>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+            
+            <?php foreach (MPAI_Diagnostics::get_categories() as $category_id => $category): ?>
+                <div id="category-<?php echo esc_attr($category_id); ?>" class="mpai-category-content" style="<?php echo $category_id === 'core' ? '' : 'display:none;'; ?>">
+                    <h3><?php echo esc_html($category['name']); ?></h3>
+                    <p><?php echo esc_html($category['description']); ?></p>
+                    
+                    <div class="mpai-test-grid">
+                        <?php 
+                        $tests = MPAI_Diagnostics::get_tests_by_category($category_id);
+                        if (!empty($tests)): 
+                            foreach ($tests as $test_id => $test): 
+                        ?>
+                            <div class="mpai-test-card" data-test-id="<?php echo esc_attr($test_id); ?>">
+                                <div class="mpai-test-header">
+                                    <h4><?php echo esc_html($test['name']); ?></h4>
+                                    <div class="mpai-test-status">
+                                        <span class="mpai-status-dot mpai-status-unknown"></span>
+                                        <span class="mpai-status-text"><?php _e('Not Run', 'memberpress-ai-assistant'); ?></span>
+                                    </div>
+                                </div>
+                                <p><?php echo esc_html($test['description']); ?></p>
+                                <div class="mpai-test-actions">
+                                    <button type="button" class="button mpai-run-test">
+                                        <?php _e('Run Test', 'memberpress-ai-assistant'); ?>
+                                    </button>
+                                    <?php if (!empty($test['direct_url'])): ?>
+                                        <a href="<?php echo esc_url(plugin_dir_url(dirname(dirname(__FILE__))) . $test['direct_url']); ?>" class="button" target="_blank">
+                                            <?php _e('Direct Test', 'memberpress-ai-assistant'); ?>
+                                        </a>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="mpai-test-result" style="display: none;"></div>
+                            </div>
+                        <?php 
+                            endforeach;
+                        else:
+                        ?>
+                            <div class="mpai-empty-tests">
+                                <p><?php _e('No tests available in this category.', 'memberpress-ai-assistant'); ?></p>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                    
+                    <?php if (count($tests) > 1): ?>
+                        <div class="mpai-category-actions">
+                            <button type="button" class="button button-secondary mpai-run-category-tests" 
+                                    data-category="<?php echo esc_attr($category_id); ?>">
+                                <?php _e('Run All Tests in Category', 'memberpress-ai-assistant'); ?>
+                            </button>
+                        </div>
+                    <?php endif; ?>
+                </div>
+            <?php endforeach; ?>
+        </div>
+        
+        <div class="mpai-global-actions">
+            <button type="button" id="mpai-run-all-tests" class="button button-primary">
+                <?php _e('Run All Diagnostics', 'memberpress-ai-assistant'); ?>
+            </button>
+        </div>
+        
+        <div id="mpai-test-results-summary" class="mpai-test-results-summary" style="display: none;">
+            <h3><?php _e('Test Results Summary', 'memberpress-ai-assistant'); ?></h3>
+            <div id="mpai-summary-content"></div>
+        </div>
+    </div>
+    
+    <?php 
+    // Legacy support - still run the mpai_run_diagnostics action for backward compatibility
+    do_action('mpai_run_diagnostics'); 
+    ?>
+</div>
+
+<style>
+/* Diagnostic System Styles */
+.mpai-diagnostics-container {
+    margin-top: 20px;
+}
+
+.mpai-category-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+    margin: 0 0 20px 0;
+    list-style: none;
+    border-bottom: 1px solid #ccc;
+}
+
+.mpai-category-tabs li {
+    margin-bottom: -1px;
+}
+
+.mpai-category-tabs a {
+    display: block;
+    padding: 8px 12px;
+    text-decoration: none;
+    margin-right: 5px;
+    border: 1px solid transparent;
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+    background: #f1f1f1;
+    color: #555;
+}
+
+.mpai-category-tabs a:hover {
+    background: #e5e5e5;
+}
+
+.mpai-category-tabs a.active {
+    background: #fff;
+    color: #000;
+    border-color: #ccc;
+    border-bottom-color: #fff;
+}
+
+.mpai-category-content {
+    margin-bottom: 30px;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-top: none;
+    padding: 20px;
+    border-radius: 0 0 4px 4px;
+}
+
+.mpai-test-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.mpai-test-card {
+    border: 1px solid #e0e0e0;
+    border-radius: 5px;
+    padding: 15px;
+    background: #f9f9f9;
+    transition: box-shadow 0.3s;
+}
+
+.mpai-test-card:hover {
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.mpai-test-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.mpai-test-header h4 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.mpai-test-status {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.mpai-status-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+}
+
+.mpai-status-unknown {
+    background-color: #bbb;
+}
+
+.mpai-status-loading {
+    background-color: #2271b1;
+    animation: pulse 1.5s infinite;
+}
+
+.mpai-status-success {
+    background-color: #46b450;
+}
+
+.mpai-status-error {
+    background-color: #dc3232;
+}
+
+.mpai-test-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 15px;
+}
+
+.mpai-test-result {
+    margin-top: 15px;
+    border-top: 1px solid #e0e0e0;
+    padding-top: 15px;
+}
+
+.mpai-test-result-content {
+    margin-bottom: 15px;
+}
+
+.mpai-result-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+    padding: 8px 12px;
+    border-radius: 4px;
+}
+
+.mpai-result-header.success {
+    background-color: rgba(70, 180, 80, 0.1);
+    color: #2e7d32;
+}
+
+.mpai-result-header.error {
+    background-color: rgba(220, 50, 50, 0.1);
+    color: #c62828;
+}
+
+.mpai-result-header h4 {
+    margin: 0;
+    font-size: 15px;
+}
+
+.mpai-result-message {
+    margin-bottom: 15px;
+}
+
+.mpai-timing-info {
+    font-size: 13px;
+    color: #777;
+    margin-bottom: 15px;
+}
+
+.mpai-subtests {
+    margin-top: 20px;
+}
+
+.mpai-doc-link {
+    margin-top: 15px;
+    font-size: 13px;
+}
+
+.mpai-category-actions {
+    margin-top: 20px;
+}
+
+.mpai-global-actions {
+    margin-top: 30px;
+    margin-bottom: 20px;
+}
+
+.mpai-test-results-summary {
+    margin-top: 30px;
+    padding: 20px;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+
+.mpai-empty-tests {
+    grid-column: 1 / -1;
+    padding: 20px;
+    text-align: center;
+    background: rgba(0,0,0,0.03);
+    border-radius: 4px;
+}
+
+@keyframes pulse {
+    0% { opacity: 1; }
+    50% { opacity: 0.4; }
+    100% { opacity: 1; }
+}
+
+/* Responsive adjustments */
+@media (max-width: 782px) {
+    .mpai-test-grid {
+        grid-template-columns: 1fr;
+    }
+    
+    .mpai-category-tabs {
+        flex-direction: column;
+        border-bottom: none;
+    }
+    
+    .mpai-category-tabs li {
+        margin-bottom: 5px;
+    }
+    
+    .mpai-category-tabs a {
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+    
+    .mpai-category-tabs a.active {
+        border-bottom-color: #ccc;
+    }
+    
+    .mpai-category-content {
+        border: 1px solid #ccc;
+        border-radius: 4px;
+    }
+}
+</style>
+
+<script>
+jQuery(document).ready(function($) {
+    // Diagnostic system
+    const MPAIDiagnostics = (function() {
+        // Private state
+        const state = {
+            runningTests: {},
+            testResults: {},
+        };
+        
+        // Public interface
+        return {
+            init: function() {
+                // Initialize all test cards
+                $('.mpai-test-card').each(function() {
+                    MPAIDiagnostics.initTestCard($(this));
+                });
+                
+                // Initialize category test buttons
+                $('.mpai-run-category-tests').on('click', function() {
+                    const category = $(this).data('category');
+                    MPAIDiagnostics.runCategoryTests(category);
+                });
+                
+                // Initialize "Run All Tests" button
+                $('#mpai-run-all-tests').on('click', function() {
+                    MPAIDiagnostics.runAllTests();
+                });
+                
+                // Initialize category tabs
+                $('.mpai-category-tabs a').on('click', function(e) {
+                    e.preventDefault();
+                    MPAIDiagnostics.switchCategory($(this).attr('href'));
+                });
+            },
+            
+            initTestCard: function($card) {
+                const testId = $card.data('test-id');
+                
+                $card.find('.mpai-run-test').on('click', function() {
+                    MPAIDiagnostics.runTest(testId, $card);
+                });
+            },
+            
+            switchCategory: function(tabId) {
+                // Remove 'active' class from all tabs
+                $('.mpai-category-tabs a').removeClass('active');
+                
+                // Add 'active' class to clicked tab
+                $('.mpai-category-tabs a[href="' + tabId + '"]').addClass('active');
+                
+                // Hide all category content
+                $('.mpai-category-content').hide();
+                
+                // Show selected category content
+                $(tabId).show();
+            },
+            
+            runTest: function(testId, $card) {
+                // Show loading state
+                $card.find('.mpai-status-dot')
+                     .removeClass('mpai-status-unknown mpai-status-success mpai-status-error')
+                     .addClass('mpai-status-loading');
+                $card.find('.mpai-status-text').text('Running...');
+                
+                const $resultContainer = $card.find('.mpai-test-result');
+                $resultContainer.html('<p>Running test...</p>').show();
+                
+                // Track running test
+                state.runningTests[testId] = true;
+                
+                // Make AJAX request
+                $.ajax({
+                    url: ajaxurl,
+                    type: 'POST',
+                    data: {
+                        action: 'mpai_run_diagnostic_test',
+                        test_id: testId,
+                        nonce: mpai_data.nonce
+                    },
+                    success: function(response) {
+                        delete state.runningTests[testId];
+                        
+                        if (response.success) {
+                            state.testResults[testId] = response.data;
+                            MPAIDiagnostics.handleTestResponse(response, $card);
+                        } else {
+                            MPAIDiagnostics.handleTestError(response.data?.message || 'Unknown error', $card);
+                        }
+                    },
+                    error: function(xhr, status, error) {
+                        delete state.runningTests[testId];
+                        MPAIDiagnostics.handleTestError(error, $card);
+                    }
+                });
+            },
+            
+            handleTestResponse: function(response, $card) {
+                const data = response.data;
+                const success = response.success && data.success;
+                
+                // Update status indicator
+                $card.find('.mpai-status-dot')
+                     .removeClass('mpai-status-unknown mpai-status-loading')
+                     .addClass(success ? 'mpai-status-success' : 'mpai-status-error');
+                $card.find('.mpai-status-text').text(success ? 'Success' : 'Failed');
+                
+                // Generate result HTML
+                let resultHtml = '<div class="mpai-test-result-content">';
+                
+                // Add header with success/failure indicator
+                resultHtml += '<div class="mpai-result-header ' + (success ? 'success' : 'error') + '">';
+                resultHtml += '<span class="dashicons ' + (success ? 'dashicons-yes-alt' : 'dashicons-warning') + '"></span>';
+                resultHtml += '<h4>' + (success ? 'Test Passed' : 'Test Failed') + '</h4>';
+                resultHtml += '</div>';
+                
+                // Add main message
+                if (data.message) {
+                    resultHtml += '<p class="mpai-result-message">' + data.message + '</p>';
+                }
+                
+                // Add timing info if available
+                if (data.timing && data.timing.total) {
+                    resultHtml += '<p class="mpai-timing-info">Execution time: ' + 
+                                  (data.timing.total * 1000).toFixed(2) + ' ms</p>';
+                }
+                
+                // Add sub-tests if available
+                if (data.tests && Object.keys(data.tests).length > 0) {
+                    resultHtml += '<div class="mpai-subtests">';
+                    resultHtml += '<h5>Detailed Results</h5>';
+                    resultHtml += '<table class="widefat">';
+                    resultHtml += '<thead><tr><th>Test</th><th>Status</th><th>Message</th></tr></thead>';
+                    resultHtml += '<tbody>';
+                    
+                    // Add each test result
+                    Object.entries(data.tests).forEach(([testName, testResult]) => {
+                        resultHtml += '<tr>';
+                        resultHtml += '<td>' + testName.replace(/_/g, ' ') + '</td>';
+                        resultHtml += '<td>' + 
+                                      (testResult.success ? 
+                                       '<span style="color: green;">✓ Pass</span>' : 
+                                       '<span style="color: red;">✗ Fail</span>') + 
+                                      '</td>';
+                        resultHtml += '<td>' + (testResult.message || '') + '</td>';
+                        resultHtml += '</tr>';
+                    });
+                    
+                    resultHtml += '</tbody></table>';
+                    resultHtml += '</div>';
+                }
+                
+                resultHtml += '</div>'; // Close mpai-test-result-content
+                
+                // Update result container
+                $card.find('.mpai-test-result').html(resultHtml);
+            },
+            
+            handleTestError: function(error, $card) {
+                // Update status indicator
+                $card.find('.mpai-status-dot')
+                     .removeClass('mpai-status-unknown mpai-status-loading')
+                     .addClass('mpai-status-error');
+                $card.find('.mpai-status-text').text('Error');
+                
+                // Generate error HTML
+                let errorHtml = '<div class="mpai-test-result-content error">';
+                errorHtml += '<div class="mpai-result-header error">';
+                errorHtml += '<span class="dashicons dashicons-warning"></span>';
+                errorHtml += '<h4>Test Error</h4>';
+                errorHtml += '</div>';
+                errorHtml += '<p class="mpai-result-message">' + error + '</p>';
+                errorHtml += '</div>';
+                
+                // Update result container
+                $card.find('.mpai-test-result').html(errorHtml);
+            },
+            
+            runCategoryTests: function(categoryId) {
+                // Get all test cards in this category
+                const $cards = $('#category-' + categoryId + ' .mpai-test-card');
+                
+                // Run each test
+                $cards.each(function() {
+                    const testId = $(this).data('test-id');
+                    MPAIDiagnostics.runTest(testId, $(this));
+                });
+            },
+            
+            runAllTests: function() {
+                // Show summary container
+                $('#mpai-test-results-summary').show();
+                $('#mpai-summary-content').html('<p>Running all tests, please wait...</p>');
+                
+                // Run all tests in each category
+                $('.mpai-category-content').each(function() {
+                    const categoryId = $(this).attr('id').replace('category-', '');
+                    MPAIDiagnostics.runCategoryTests(categoryId);
+                });
+                
+                // Update summary after all tests complete (simplified)
+                setTimeout(function() {
+                    let summaryHtml = '<p>All tests have been initiated. Check individual test cards for results.</p>';
+                    $('#mpai-summary-content').html(summaryHtml);
+                }, 500);
+            }
+        };
+    })();
+    
+    // Initialize diagnostics system
+    MPAIDiagnostics.init();
+});
+</script>

--- a/includes/tests/load-tests.php
+++ b/includes/tests/load-tests.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Test Loader
+ * 
+ * Loads all diagnostic test files
+ * 
+ * @package MemberPress AI Assistant
+ */
+
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+
+// Define the directory containing test files
+$tests_dir = MPAI_PLUGIN_DIR . 'includes/tests';
+
+// Include the system info test
+if (file_exists($tests_dir . '/system-info-test.php')) {
+    include_once $tests_dir . '/system-info-test.php';
+}
+
+// Add hooks to allow plugins and themes to register tests
+function mpai_register_diagnostic_tests() {
+    do_action('mpai_register_diagnostic_tests');
+}
+add_action('init', 'mpai_register_diagnostic_tests', 20);

--- a/includes/tests/system-info-test.php
+++ b/includes/tests/system-info-test.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * System Information Test
+ * 
+ * Provides detailed information about the WordPress and PHP environment
+ * 
+ * @package MemberPress AI Assistant
+ */
+
+// If this file is called directly, abort.
+if (!defined('WPINC')) {
+    die;
+}
+
+/**
+ * Run system information test
+ * 
+ * @param array $params Test parameters
+ * @return array Test results
+ */
+function mpai_run_system_info_test($params = []) {
+    $start_time = microtime(true);
+    
+    // WordPress Information
+    $wp_info = [
+        'version' => get_bloginfo('version'),
+        'site_url' => get_bloginfo('url'),
+        'home_url' => get_home_url(),
+        'is_multisite' => is_multisite() ? 'Yes' : 'No',
+        'memory_limit' => WP_MEMORY_LIMIT,
+        'debug_mode' => defined('WP_DEBUG') && WP_DEBUG ? 'Enabled' : 'Disabled',
+        'timezone' => get_option('timezone_string') ?: get_option('gmt_offset'),
+        'language' => get_locale(),
+        'permalink_structure' => get_option('permalink_structure') ? get_option('permalink_structure') : 'Default',
+    ];
+    
+    // PHP Information
+    $php_info = [
+        'version' => phpversion(),
+        'os' => PHP_OS,
+        'memory_limit' => ini_get('memory_limit'),
+        'max_execution_time' => ini_get('max_execution_time'),
+        'post_max_size' => ini_get('post_max_size'),
+        'upload_max_filesize' => ini_get('upload_max_filesize'),
+        'max_input_vars' => ini_get('max_input_vars'),
+        'safe_mode' => ini_get('safe_mode') ? 'Enabled' : 'Disabled',
+        'extensions' => get_loaded_extensions(),
+    ];
+    
+    // Plugin Information
+    $active_plugins = get_option('active_plugins');
+    $plugin_info = [];
+    
+    foreach ($active_plugins as $plugin) {
+        $plugin_data = get_plugin_data(WP_PLUGIN_DIR . '/' . $plugin);
+        $plugin_info[] = [
+            'name' => $plugin_data['Name'],
+            'version' => $plugin_data['Version'],
+            'author' => $plugin_data['Author'],
+        ];
+    }
+    
+    // MemberPress Specific Information
+    $memberpress_info = [
+        'active' => class_exists('MeprAppCtrl') ? 'Yes' : 'No'
+    ];
+    
+    if (class_exists('MeprAppCtrl')) {
+        if (defined('MEPR_VERSION')) {
+            $memberpress_info['version'] = MEPR_VERSION;
+        }
+        
+        // Get MemberPress options
+        $mepr_options = get_option('mepr_options');
+        if (is_array($mepr_options)) {
+            $memberpress_info['payment_methods'] = isset($mepr_options['payments_enabled']) ? count($mepr_options['payments_enabled']) : 0;
+            $memberpress_info['account_page'] = isset($mepr_options['account_page_id']) ? get_the_title($mepr_options['account_page_id']) : 'Not set';
+            $memberpress_info['login_page'] = isset($mepr_options['login_page_id']) ? get_the_title($mepr_options['login_page_id']) : 'Not set';
+            $memberpress_info['thank_you_page'] = isset($mepr_options['thankyou_page_id']) ? get_the_title($mepr_options['thankyou_page_id']) : 'Not set';
+        }
+    }
+    
+    // MemberPress AI Assistant Information
+    $mpai_info = [
+        'version' => defined('MPAI_VERSION') ? MPAI_VERSION : 'Unknown',
+        'primary_api' => get_option('mpai_primary_api', 'openai'),
+        'has_openai_api_key' => !empty(get_option('mpai_api_key', '')),
+        'has_anthropic_api_key' => !empty(get_option('mpai_anthropic_api_key', '')),
+        'console_logging' => get_option('mpai_enable_console_logging', '0') === '1' ? 'Enabled' : 'Disabled',
+    ];
+    
+    // Run sub-tests
+    $sub_tests = [
+        'wp_version' => [
+            'success' => version_compare(get_bloginfo('version'), '5.0', '>='),
+            'message' => 'WordPress version: ' . get_bloginfo('version') . (version_compare(get_bloginfo('version'), '5.0', '>=') ? ' (Compatible)' : ' (Not compatible - requires 5.0+)')
+        ],
+        'php_version' => [
+            'success' => version_compare(phpversion(), '7.0', '>='),
+            'message' => 'PHP version: ' . phpversion() . (version_compare(phpversion(), '7.0', '>=') ? ' (Compatible)' : ' (Not compatible - requires 7.0+)')
+        ],
+        'memory_limit' => [
+            'success' => strpos(ini_get('memory_limit'), 'M') !== false && (int)ini_get('memory_limit') >= 64,
+            'message' => 'Memory limit: ' . ini_get('memory_limit') . ((int)ini_get('memory_limit') >= 64 ? ' (Sufficient)' : ' (May be insufficient - 64M+ recommended)')
+        ],
+        'max_execution_time' => [
+            'success' => ini_get('max_execution_time') >= 30 || ini_get('max_execution_time') == 0,
+            'message' => 'Max execution time: ' . ini_get('max_execution_time') . (ini_get('max_execution_time') >= 30 || ini_get('max_execution_time') == 0 ? ' (Sufficient)' : ' (May be insufficient - 30+ seconds recommended)')
+        ],
+        'memberpress_integration' => [
+            'success' => class_exists('MeprAppCtrl'),
+            'message' => 'MemberPress: ' . (class_exists('MeprAppCtrl') ? 'Detected' : 'Not detected')
+        ],
+        'api_configurations' => [
+            'success' => !empty(get_option('mpai_api_key', '')) || !empty(get_option('mpai_anthropic_api_key', '')),
+            'message' => 'API Configuration: ' . (!empty(get_option('mpai_api_key', '')) || !empty(get_option('mpai_anthropic_api_key', '')) ? 'At least one API key is configured' : 'No API keys configured')
+        ]
+    ];
+    
+    // Calculate overall success based on critical tests
+    $critical_tests = ['wp_version', 'php_version', 'api_configurations'];
+    $critical_success = true;
+    
+    foreach ($critical_tests as $test_id) {
+        if (!$sub_tests[$test_id]['success']) {
+            $critical_success = false;
+            break;
+        }
+    }
+    
+    // Count test results
+    $total_tests = count($sub_tests);
+    $passed_tests = 0;
+    
+    foreach ($sub_tests as $test) {
+        if ($test['success']) {
+            $passed_tests++;
+        }
+    }
+    
+    $end_time = microtime(true);
+    
+    return [
+        'success' => $critical_success,
+        'message' => $critical_success 
+            ? 'System information test completed successfully. ' . $passed_tests . '/' . $total_tests . ' tests passed.'
+            : 'System information test completed with some issues. ' . $passed_tests . '/' . $total_tests . ' tests passed.',
+        'data' => [
+            'wp' => $wp_info,
+            'php' => $php_info,
+            'plugins' => $plugin_info,
+            'memberpress' => $memberpress_info,
+            'mpai' => $mpai_info
+        ],
+        'tests' => $sub_tests,
+        'timing' => [
+            'start' => $start_time,
+            'end' => $end_time,
+            'total' => $end_time - $start_time
+        ]
+    ];
+}
+
+// Register the test if called via MPAI_Diagnostics
+if (class_exists('MPAI_Diagnostics')) {
+    MPAI_Diagnostics::register_test([
+        'id' => 'system-info',
+        'category' => 'core',
+        'name' => __('System Information', 'memberpress-ai-assistant'),
+        'description' => __('Get detailed information about your WordPress and PHP environment', 'memberpress-ai-assistant'),
+        'test_callback' => 'mpai_run_system_info_test',
+        'doc_url' => 'system-information.md'
+    ]);
+}

--- a/memberpress-ai-assistant.php
+++ b/memberpress-ai-assistant.php
@@ -165,6 +165,9 @@ class MemberPress_AI_Assistant {
         // Enqueue admin menu icon styles on all admin pages
         add_action('admin_enqueue_scripts', array($this, 'enqueue_admin_menu_styles'));
         
+        // Fix menu highlighting for settings page
+        add_action('admin_head', array($this, 'fix_global_menu_highlighting'));
+        
         // Process consent form submissions
         add_action('admin_init', array($this, 'process_consent_form'));
         
@@ -271,6 +274,15 @@ class MemberPress_AI_Assistant {
                     break;
                 }
             }
+        }
+        
+        // Special case for settings page - Always force MemberPress detection on settings page
+        // This ensures the MemberPress menu is highlighted and visible
+        global $pagenow;
+        if (($pagenow === 'admin.php' && isset($_GET['page']) && $_GET['page'] === 'memberpress-ai-assistant-settings') ||
+            (isset($plugin_page) && $plugin_page === 'memberpress-ai-assistant-settings')) {
+            $has_memberpress = true;
+            error_log('MPAI DEBUG: Force-enabling MemberPress detection on settings page for menu highlight');
         }
         
         // Store the result
@@ -488,6 +500,9 @@ class MemberPress_AI_Assistant {
      * Settings page load hook
      */
     public function settings_page_load() {
+        // Register a late-running action to fix menu highlighting
+        add_action('admin_head', array($this, 'fix_settings_page_menu_highlight'), 9999);
+        
         // Register settings
         register_setting('mpai_options', 'mpai_api_key');
         register_setting('mpai_options', 'mpai_model');
@@ -559,9 +574,49 @@ class MemberPress_AI_Assistant {
     }
 
     /**
+     * Fix menu highlighting for settings page
+     * This function runs in admin_head to directly manipulate the global variables
+     * responsible for menu highlighting
+     */
+    public function fix_settings_page_menu_highlight() {
+        global $parent_file, $submenu_file, $plugin_page;
+        
+        // Only run on our settings page
+        if ($plugin_page !== 'memberpress-ai-assistant-settings') {
+            return;
+        }
+        
+        // Force MemberPress detection
+        $this->check_memberpress();
+        
+        if ($this->has_memberpress) {
+            // Set the global variables directly
+            $parent_file = 'memberpress';
+            $submenu_file = 'memberpress-ai-assistant-settings';
+            
+            // Add JavaScript to ensure menu is visible
+            echo "<script>
+                jQuery(document).ready(function($) {
+                    // Highlight the MemberPress menu
+                    $('#toplevel_page_memberpress').addClass('wp-has-current-submenu wp-menu-open').removeClass('wp-not-current-submenu');
+                    $('#toplevel_page_memberpress > a').addClass('wp-has-current-submenu wp-menu-open').removeClass('wp-not-current-submenu');
+                    
+                    // Find and highlight our submenu item
+                    $('#toplevel_page_memberpress .wp-submenu li a[href*=\"memberpress-ai-assistant-settings\"]').parent().addClass('current');
+                });
+            </script>";
+            
+            error_log('MPAI DEBUG: Fixed menu highlighting in admin_head with JS');
+        }
+    }
+    
+    /**
      * Display settings page
      */
     public function display_settings_page() {
+        // Make sure MemberPress status is checked
+        $this->check_memberpress();
+        
         require_once MPAI_PLUGIN_DIR . 'includes/settings-page.php';
     }
 
@@ -830,6 +885,50 @@ class MemberPress_AI_Assistant {
             array(),
             MPAI_VERSION
         );
+    }
+    
+    /**
+     * Fix menu highlighting globally by using JavaScript
+     * This runs on all admin pages but only applies fixes when needed
+     */
+    public function fix_global_menu_highlighting() {
+        // Only run in admin
+        if (!is_admin()) {
+            return;
+        }
+        
+        // Get the current page from URL
+        $current_page = isset($_GET['page']) ? sanitize_text_field($_GET['page']) : '';
+        
+        // Special handling for our settings page
+        if ($current_page === 'memberpress-ai-assistant-settings') {
+            // Force check MemberPress status
+            $this->check_memberpress();
+            
+            if ($this->has_memberpress) {
+                // Add JavaScript to fix menu highlighting
+                ?>
+                <script type="text/javascript">
+                jQuery(document).ready(function($) {
+                    // Ensure MemberPress menu is highlighted and expanded
+                    $('#toplevel_page_memberpress')
+                        .addClass('wp-has-current-submenu wp-menu-open')
+                        .removeClass('wp-not-current-submenu');
+                    
+                    $('#toplevel_page_memberpress > a')
+                        .addClass('wp-has-current-submenu wp-menu-open')
+                        .removeClass('wp-not-current-submenu');
+                    
+                    // Highlight our AI Assistant submenu item
+                    $('#toplevel_page_memberpress .wp-submenu li a[href*="memberpress-ai-assistant-settings"]')
+                        .parent().addClass('current');
+                    
+                    console.log('MemberPress AI: Fixed menu highlighting for settings page');
+                });
+                </script>
+                <?php
+            }
+        }
     }
 
     /**

--- a/memberpress-ai-assistant.php
+++ b/memberpress-ai-assistant.php
@@ -356,6 +356,16 @@ class MemberPress_AI_Assistant {
             require_once MPAI_PLUGIN_DIR . 'test/integration/register-integration-tests.php';
         }
         
+        // Load the new diagnostics system
+        if (is_admin() && file_exists(MPAI_PLUGIN_DIR . 'includes/class-mpai-diagnostics.php')) {
+            require_once MPAI_PLUGIN_DIR . 'includes/class-mpai-diagnostics.php';
+            
+            // Load test files
+            if (file_exists(MPAI_PLUGIN_DIR . 'includes/tests/load-tests.php')) {
+                require_once MPAI_PLUGIN_DIR . 'includes/tests/load-tests.php';
+            }
+        }
+        
         // CLI Commands - always load to ensure early initialization
         // The CLI commands file itself handles WP-CLI availability checks
         require_once MPAI_PLUGIN_DIR . 'includes/cli/class-mpai-cli-commands.php';

--- a/test/debug-menu.php
+++ b/test/debug-menu.php
@@ -1,0 +1,12 @@
+<?php
+// This is a simple script to debug current globals
+echo '<pre>';
+global $menu, $submenu, $parent_file, $submenu_file, $plugin_page;
+echo 'Current plugin page: ' . $plugin_page . "
+";
+echo 'Current parent file: ' . $parent_file . "
+";
+echo 'Current submenu file: ' . $submenu_file . "
+";
+echo '</pre>';
+?>


### PR DESCRIPTION
The changes have been committed successfully! Here's a summary of what was fixed:

  1. The MemberPress menu wasn't showing when viewing the settings page at
  wp-admin/admin.php?page=memberpress-ai-assistant-settings.
  2. The solution implemented includes:
    - Server-side manipulation of WordPress menu globals
    - Client-side JavaScript to directly apply the correct CSS classes
    - Enhanced MemberPress detection when on the settings page
    - Global admin_head hook to ensure consistent menu behavior
  3. The commit message explains the changes and includes the Scooby Snack tag to track the successful fix.

  This fix ensures that when users navigate to the settings page (memberpress-ai-assistant-settings), the MemberPress menu will
  remain visible and properly highlighted, just like it does when viewing the dashboard page.
